### PR TITLE
Fix get file info - end with error when reaching max retries.

### DIFF
--- a/MyDownloader.Core/Downloader.cs
+++ b/MyDownloader.Core/Downloader.cs
@@ -552,7 +552,8 @@ namespace MyDownloader.Core
                     }
                     else
                     {
-                        SetState(DownloaderState.NeedToPrepare);
+                        lastError = ex;
+                        SetState(DownloaderState.EndedWithError);
                         return;
                     }
                 }


### PR DESCRIPTION
This PR should solve the problem of downloader entering NeedToPrepare state after trying to get file info with max retries defined in settings.